### PR TITLE
Update all resource auto-completes to use single-quotes

### DIFF
--- a/Conditional Execution/not_if.sublime-snippet
+++ b/Conditional Execution/not_if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-not_if "$0"
+not_if '$0'
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>not_if</tabTrigger>

--- a/Conditional Execution/only_if.sublime-snippet
+++ b/Conditional Execution/only_if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-only_if "$0"
+only_if '$0'
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>only_if</tabTrigger>

--- a/Cookbook File/cookbook_file-full.sublime-snippet
+++ b/Cookbook File/cookbook_file-full.sublime-snippet
@@ -1,14 +1,14 @@
 <snippet>
 	<content><![CDATA[
-cookbook_file "${1:name}" do
+cookbook_file '${1:name}' do
 	action :${2:create}
-	path "${3:path}"
-	source "${4:source}"
-	owner "${5:root}"
-	group "${6:root}"
-	mode "${7:0644}"
+	path '${3:path}'
+	source '${4:source}'
+	owner '${5:root}'
+	group '${6:root}'
+	mode '${7:0644}'
 	backup ${8:5}
-	cookbook "${9:cookbook}"
+	cookbook '${9:cookbook}'
 end
 
 ]]></content>

--- a/Cookbook File/cookbook_file.sublime-snippet
+++ b/Cookbook File/cookbook_file.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-cookbook_file "${1:name}" do
-	source "${2:source}"
-	owner "root"
-	group "root"
-	mode "0644"
+cookbook_file '${1:name}' do
+	source '${2:source}'
+	owner 'root'
+	group 'root'
+	mode '0644'
 end
 
 ]]></content>

--- a/Cron/cron-full.sublime-snippet
+++ b/Cron/cron-full.sublime-snippet
@@ -1,17 +1,17 @@
 <snippet>
 	<content><![CDATA[
-cron "${1:name}" do
-	hour "${2:*}"
-	minute "${3:*}"
-	day "${4:*}"
-	month "${5:*}"
-	weekday "${6:*}"
-	command "${7:/bin/true}"
-	user "${8:root}"
-	mailto "${9:root@example.com}"
-	path "${10:/bin:/usr/bin}"
-	home "${11:/tmp}"
-	shell "${12:/bin/bash}"
+cron '${1:name}' do
+	hour '${2:*}'
+	minute '${3:*}'
+	day '${4:*}'
+	month '${5:*}'
+	weekday '${6:*}'
+	command '${7:/bin/true}'
+	user '${8:root}'
+	mailto '${9:root@example.com}'
+	path '${10:/bin:/usr/bin}'
+	home '${11:/tmp}'
+	shell '${12:/bin/bash}'
 end
 
 ]]></content>

--- a/Cron/cron.sublime-snippet
+++ b/Cron/cron.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
-cron "${1:name}" do
-	hour "${2:5}"
-	minute "${3:0}"
-	command "${4:/bin/true}"
+cron '${1:name}' do
+	hour '${2:5}'
+	minute '${3:0}'
+	command '${4:/bin/true}'
 end
 
 ]]></content>

--- a/Deploy/deploy.sublime-snippet
+++ b/Deploy/deploy.sublime-snippet
@@ -1,18 +1,18 @@
 <snippet>
 	<content><![CDATA[
-deploy "/my/deploy/dir" do
-	repo "git@github.com/whoami/project"
-	revision "abc123" # or "HEAD" or "TAG_for_1.0" or (subversion) "1234"
-	user "deploy_ninja"
-	enable_submodules true
-	migrate true
-	migration_command "rake db:migrate"
-	environment "RAILS_ENV" => "production", "OTHER_ENV" => "foo"
-	shallow_clone true
-	action :deploy # or :rollback
-	restart_command "touch tmp/restart.txt"
-	git_ssh_wrapper "wrap-ssh4git.sh"
-	scm_provider Chef::Provider::Git # is the default, for svn: Chef::Provider::Subversion
+deploy '${1:/my/deploy/dir}' do
+	repo '${2:git@github.com/whoami/project}'
+	revision '${3:abc123}' # or 'HEAD' or 'TAG_for_1.0' or (subversion) '1234'
+	user '${4:deploy_ninja}'
+	enable_submodules ${5:true}
+	migrate ${6:true}
+	migration_command '${7:rake db:migrate}'
+	environment '${8:RAILS_ENV}' => '${9:production}', '${10:OTHER_ENV}' => '${11:foo}'
+	shallow_clone ${12:true}
+	action :${13:deploy} # or :rollback
+	restart_command '${14:touch tmp/restart.txt}'
+	git_ssh_wrapper '${15:wrap-ssh4git.sh}'
+	scm_provider ${16:Chef::Provider::Git} # is the default, for svn: Chef::Provider::Subversion
 end
 
 ]]></content>

--- a/Directory/directory-full.sublime-snippet
+++ b/Directory/directory-full.sublime-snippet
@@ -1,12 +1,12 @@
 <snippet>
 	<content><![CDATA[
-directory "${1:name}" do
-	action :${2:create}
-	owner "${3:root}"
-	group "${4:root}"
-	mode "${5:0755}"
-	path "${6:name}"
-	recursive ${7:false}
+directory '${1:name}' do
+	owner '${2:root}'
+	group '${3:root}'
+	mode '${4:0755}'
+	path '${5:name}'
+	recursive ${6:false}
+	action :${7:create}
 end
 
 ]]></content>

--- a/Directory/directory-recursive.sublime-snippet
+++ b/Directory/directory-recursive.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-directory "${1:name}" do
-	owner "root"
-	group "root"
-	mode "0755"
-	action :create
+directory '${1:name}' do
+	owner '${2:root}'
+	group '${3:root}'
+	mode '${4:0755}'
+	action :${5:create}
 	recursive true
 end
 

--- a/Directory/directory.sublime-snippet
+++ b/Directory/directory.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
-directory "${1:name}" do
-	owner "root"
-	group "root"
-	mode "0755"
+directory '${1:name}' do
+	owner 'root'
+	group 'root'
+	mode '0755'
 	action :create
 end
 

--- a/Env/env.sublime-snippet
+++ b/Env/env.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
-env "${1:ComSpec}" do
-	value "${2:C:\\Windows\\system32\\cmd.exe}"
+env '${1:ComSpec}' do
+	value '${2:C:\\Windows\\system32\\cmd.exe}''
 end
 
 ]]></content>

--- a/Erlang Call/erl_call.sublime-snippet
+++ b/Erlang Call/erl_call.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
-erl_call "${1:list names}" do
-	code "${2:net_adm:names().}"
+erl_call '${1:list names}' do
+	code '${2:net_adm:names().}'
 	distributed ${3:false}
-	node_name "${4:chef@localhost}"
+	node_name '${4:chef@localhost}'
 end
 
 ]]></content>

--- a/Execute/execute-full.sublime-snippet
+++ b/Execute/execute-full.sublime-snippet
@@ -1,17 +1,17 @@
 <snippet>
 	<content><![CDATA[
-execute "${1:name}" do
+execute '${1:name}' do
 	action :${2:run}
-	command "${3:ls -la}"
-	creates "${4:/tmp/something}"
-	cwd "${5:/tmp}"
+	command '${3:ls -la}'
+	creates '${4:/tmp/something}'
+	cwd '${5:/tmp}'
 	environment ({${6:'HOME' => '/home/myhome'}})
-	user "${7:root}"
-	group "${8:root}"
-	path "${9:['/opt/bin','/opt/sbin']}"
+	user '${7:root}'
+	group '${8:root}'
+	path '${9:['/opt/bin','/opt/sbin']}'
 	timeout ${10:3600}
 	returns ${11:0}
-	umask "${12:022}"
+	umask '${12:022}'
 end
 
 ]]></content>

--- a/Execute/execute-nothing.sublime-snippet
+++ b/Execute/execute-nothing.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
-execute "${1:name}" do
-	command "${2:ls -la}"
+execute '${1:name}' do
+	command '${2:ls -la}'
 	action :${3:nothing}
 end
 

--- a/Execute/execute.sublime-snippet
+++ b/Execute/execute.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-execute "${1:name}" do
-	command "${2:ls -la}"
-	creates "${3:/tmp/something}"
+execute '${1:name}' do
+	command '${2:ls -la}'
+	creates '${3:/tmp/something}'
 	action :${4:run}
 end
 

--- a/File/file-content.sublime-snippet
+++ b/File/file-content.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[
-file "${1:name}" do
+file '${1:name}' do
 	action :create
-	owner "root"
-	group "root"
-	mode "0644"
-	content "${2:content here}"
+	owner 'root'
+	group 'root'
+	mode '0644'
+	content '${2:content here}'
 end
 
 ]]></content>

--- a/File/file-full.sublime-snippet
+++ b/File/file-full.sublime-snippet
@@ -1,13 +1,13 @@
 <snippet>
 	<content><![CDATA[
-file "${1:name}" do
+file '${1:name}' do
 	action :${2:create}
-	path "${3:path}"
+	path '${3:path}'
 	backup ${4:5}
-	owner "${5:root}"
-	group "${6:root}"
-	mode "${7:0644}"
-	content "${8:content here}"
+	owner '${5:root}'
+	group '${6:root}'
+	mode '${7:0644}'
+	content '${8:content here}'
 end
 
 ]]></content>

--- a/File/file.sublime-snippet
+++ b/File/file.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-file "${1:name}" do
+file '${1:name}' do
 	action :create
-	owner "root"
-	group "root"
-	mode "0644"
+	owner 'root'
+	group 'root'
+	mode '0644'
 end
 
 ]]></content>

--- a/Group/group-append.sublime-snippet
+++ b/Group/group-append.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-group "${1:name}" do
+group '${1:name}' do
 	action :create
 	gid ${2:999}
 	members [${3:'paco'}]

--- a/Group/group.sublime-snippet
+++ b/Group/group.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-group "${1:name}" do
+group '${1:name}' do
 	action :create
 	gid ${2:999}
 	members [${3:'paco','vicente'}]

--- a/HTTP Request/http_request-post.sublime-snippet
+++ b/HTTP Request/http_request-post.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[
-authorization = "Basic #{Base64.encode64('username:password')}"
-http_request "${1:posting data}" do
+authorization = 'Basic #{Base64.encode64('username:password')}'
+http_request '${1:posting data}' do
 	action :post
-	url "${2:http://example.com/check_in}"
-	message ${3::some => "data"}
-	headers (${4:\{"AUTHORIZATION" => authorization\}})
+	url '${2:http://example.com/check_in}'
+	message ${3::some => 'data'}
+	headers (${4:\{'AUTHORIZATION' => authorization\}})
 end
 
 ]]></content>

--- a/HTTP Request/http_request.sublime-snippet
+++ b/HTTP Request/http_request.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
-http_request "${1:some message}" do
-	url "${2:http://example.com/check_in}"
+http_request '${1:some message}' do
+	url '${2:http://example.com/check_in}'
 end
 
 ]]></content>

--- a/Include/include_recipe.sublime-snippet
+++ b/Include/include_recipe.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-include_recipe "${0:example::recipe}"
+include_recipe '${0:example::recipe}'
 
 ]]></content>
   <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->

--- a/Link/link-full.sublime-snippet
+++ b/Link/link-full.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-link "${1:/tmp/passwd}" do
-	to "${2:/etc/passwd}"
+link '${1:/tmp/passwd}' do
+	to '${2:/etc/passwd}'
 	link_type :${3:symbolic}
-	owner "${4:root}"
-	group "${5:root}"
+	owner '${4:root}'
+	group '${5:root}'
 end
 
 ]]></content>

--- a/Link/link-hard.sublime-snippet
+++ b/Link/link-hard.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
-link "${1:/tmp/passwd}" do
-	to "${2:/etc/passwd}"
+link '${1:/tmp/passwd}' do
+	to '${2:/etc/passwd}'
 	link_type :hard
 end
 

--- a/Link/link.sublime-snippet
+++ b/Link/link.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
-link "${1:/tmp/passwd}" do
-	to "${2:/etc/passwd}"
+link '${1:/tmp/passwd}' do
+	to '${2:/etc/passwd}'
 end
 
 ]]></content>

--- a/Log/log-debug.sublime-snippet
+++ b/Log/log-debug.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-log ("${0:your string to log}") { level :debug }
+log ('${0:your string to log}') { level :debug }
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>logd</tabTrigger>

--- a/Log/log.sublime-snippet
+++ b/Log/log.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-log "${0:your string to log}"
+log '${0:your string to log}'
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>log</tabTrigger>

--- a/Mdadm/mdadm.sublime-snippet
+++ b/Mdadm/mdadm.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
-mdadm "${1:/dev/md0}" do
-	devices [ ${2:"/dev/sda", "/dev/sdb"} ]
+mdadm '${1:/dev/md0}' do
+	devices [ ${2:'/dev/sda', '/dev/sdb'} ]
 	level ${3:1}
 	chunk ${4:64}
 	action [ ${5::create, :assemble} ]

--- a/Metadata/metadata.sublime-snippet
+++ b/Metadata/metadata.sublime-snippet
@@ -1,12 +1,12 @@
 <snippet>
   <content><![CDATA[
-name             "${1:example}"
-maintainer       "${2:YOUR_COMPANY_NAME}"
-maintainer_email "${3:YOUR_EMAIL}"
-license          "${4:All rights reserved}"
-description      "${5:Installs/Configures example}"
+name             '${1:example}'
+maintainer       '${2:The Authors}'
+maintainer_email '${3:you@example.com}'
+license          '${4:All rights reserved}'
+description      '${5:Installs/Configures example}'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "${6:0.1.0}"
+version          '${6:0.1.0}'
 
 ]]></content>
   <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->

--- a/Metadata/metadataf.sublime-snippet
+++ b/Metadata/metadataf.sublime-snippet
@@ -1,22 +1,22 @@
 <snippet>
   <content><![CDATA[
-name             "example"
-maintainer       "YOUR_COMPANY_NAME"
-maintainer_email "YOUR_EMAIL"
-license          "All rights reserved"
-description      "Installs/Configures example"
+name             'example'
+maintainer       'The Authors'
+maintainer_email 'you@example.com'
+license          'All rights reserved'
+description      'Installs/Configures example'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
-depends          "package"
-attribute        "pets/cat/name",:display_name => "Cat Name"
-grouping         "pets/cat",:title => "Cat Options"
-conflicts        "package"
-provides         "service[example]"
-recipe           "example::one", "Description for example"
-recommends       "package"
-replaces         "package"
-supports         "ubuntu"
-suggests         "package"
+version          '0.1.0'
+depends          'package'
+attribute        'pets/cat/name',:display_name => 'Cat Name'
+grouping         'pets/cat',:title => 'Cat Options'
+conflicts        'package'
+provides         'service[example]'
+recipe           'example::one', 'Description for example'
+recommends       'package'
+replaces         'package'
+supports         'ubuntu'
+suggests         'package'
 $0
 ]]></content>
   <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->

--- a/Mount/mount-full.sublime-snippet
+++ b/Mount/mount-full.sublime-snippet
@@ -1,13 +1,13 @@
 <snippet>
 	<content><![CDATA[
-mount "${1:/mnt/volume1}" do
-	action [${2::mount, :enable}]
-	device "${3:/dev/sda}"
-	device_type :${4:device}
-	fstype "${5:xfs}"
-	options "${6:rw}"
-	dump ${7:0}
-	pass ${8:2}
+mount '${1:/mnt/volume1}' do
+	device '${2:/dev/sda}'
+	device_type :${3:device}
+	fstype '${4:xfs}'
+	options '${5:rw}'
+	dump ${6:0}
+	pass ${7:2}
+	action [${8::mount, :enable}]
 end
 
 ]]></content>

--- a/Mount/mount-label.sublime-snippet
+++ b/Mount/mount-label.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-mount "${1:/mnt/volume1}" do
-	device "${2:volume1}"
+mount '${1:/mnt/volume1}' do
+	device '${2:volume1}'
 	device_type :label
-	fstype "${3:xfs}"
-	options "${4:rw}"
+	fstype '${3:xfs}'
+	options '${4:rw}'
 end
 
 ]]></content>

--- a/Mount/mount-network.sublime-snippet
+++ b/Mount/mount-network.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
-mount "${1:/mnt/local}" do
-	device "${2:nas1prod:/export/web_sites}"
-	fstype "${3:nfs}"
-	options "${4:rw}"
+mount '${1:/mnt/local}' do
+	device '${2:nas1prod:/export/web_sites}'
+	fstype '${3:nfs}'
+	options '${4:rw}'
 	action [${5::mount, :enable}]
 end
 

--- a/Mount/mount.sublime-snippet
+++ b/Mount/mount.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-mount "${1:/mnt/local}" do
-	device "${2:/dev/sdb1}"
-	fstype "${3:ext3}"
+mount '${1:/mnt/local}' do
+	device '${2:/dev/sdb1}'
+	fstype '${3:ext3}'
 end
 
 ]]></content>

--- a/Notifications/notifies-immediately.sublime-snippet
+++ b/Notifications/notifies-immediately.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-notifies :${1:restart}, "${2:service}[${3:name}]", :immediately
+notifies :${1:restart}, '${2:service}[${3:name}]', :immediately
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>notifiesi</tabTrigger>

--- a/Notifications/notifies.sublime-snippet
+++ b/Notifications/notifies.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-notifies :${1:restart}, "${2:service}[${3:name}]"
+notifies :${1:restart}, '${2:service}[${3:name}]'
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>notifies</tabTrigger>

--- a/Notifications/subscribes-immediately.sublime-snippet
+++ b/Notifications/subscribes-immediately.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-subscribes :${1:restart}, "${2:template}[${3:name}]", :immediately
+subscribes :${1:restart}, '${2:template}[${3:name}]', :immediately
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>subscribesi</tabTrigger>

--- a/Notifications/subscribes.sublime-snippet
+++ b/Notifications/subscribes.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-subscribes :${1:restart}, "${2:template}[${3:name}]"
+subscribes :${1:restart}, '${2:template}[${3:name}]'
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>subscribes</tabTrigger>

--- a/Ohai/ohai-plugin.sublime-snippet
+++ b/Ohai/ohai-plugin.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-ohai "reload" do
+ohai 'reload' do
 	action :reload
-	plugin "${1:passwd}"
+	plugin '${1:passwd}'
 end
 
 ]]></content>

--- a/Ohai/ohai.sublime-snippet
+++ b/Ohai/ohai.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-ohai "reload" do
+ohai 'reload' do
 	action :reload
 end
 

--- a/Package/package-options.sublime-snippet
+++ b/Package/package-options.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
-package "${1:name}" do
+package '${1:name}' do
 	action :${2:install}
-	version "${3:1.0-1}"
-	options "${4:-t wheezy}"
+	version '${3:1.0-1}'
+	options '${4:-t wheezy}'
 end
 
 ]]></content>

--- a/Package/package-response_file.sublime-snippet
+++ b/Package/package-response_file.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-package "${1:name}" do
+package '${1:name}' do
 	action :${2:install}
-	response_file "${3:name.seed}"
+	response_file '${3:name.seed}'
 end
 
 ]]></content>

--- a/Package/package-version.sublime-snippet
+++ b/Package/package-version.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-package "${1:name}" do
+package '${1:name}' do
 	action :${2:install}
-	version "${3:1.0-1}"
+	version '${3:1.0-1}'
 end
 
 ]]></content>

--- a/Package/package.sublime-snippet
+++ b/Package/package.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-package "${1:name}" do
+package '${1:name}' do
 	action :${2:install}
 end
 

--- a/Remote Directory/remote_directory-full.sublime-snippet
+++ b/Remote Directory/remote_directory-full.sublime-snippet
@@ -1,14 +1,14 @@
 <snippet>
 	<content><![CDATA[
-remote_directory "${1:/tmp/remote_something}" do
-	source "${2:something}"
+remote_directory '${1:/tmp/remote_something}' do
+	source '${2:something}'
 	files_backup ${3:10}
-	files_owner "${4:root}"
-	files_group "${5:root}"
-	files_mode "${6:0644}"
-	owner "${7:root}"
-	group "${8:root}"
-	mode "${9:0755}"
+	files_owner '${4:root}'
+	files_group '${5:root}'
+	files_mode '${6:0644}'
+	owner '${7:root}'
+	group '${8:root}'
+	mode '${9:0755}'
 	cookbook ${10:nil}
 	purge ${11:false}
 	overwrite ${12:true}

--- a/Remote Directory/remote_directory.sublime-snippet
+++ b/Remote Directory/remote_directory.sublime-snippet
@@ -1,13 +1,13 @@
 <snippet>
 	<content><![CDATA[
-remote_directory "${1:/tmp/remote_something}" do
-	source "${2:something}"
-	files_owner "${3:root}"
-	files_group "${4:root}"
-	files_mode "${5:0644}"
-	owner "${6:root}"
-	group "${7:root}"
-	mode "${8:0755}"
+remote_directory '${1:/tmp/remote_something}' do
+	source '${2:something}'
+	files_owner '${3:root}'
+	files_group '${4:root}'
+	files_mode '${5:0644}'
+	owner '${6:root}'
+	group '${7:root}'
+	mode '${8:0755}'
 end
 
 ]]></content>

--- a/Remote File/remote_file.sublime-snippet
+++ b/Remote File/remote_file.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
   <content><![CDATA[
-remote_file "${1:/tmp/remote_file}" do
-  owner "${2:root}"
-  group "${3:root}"
-  mode "${4:0644}"
-  source "${5:http://www.example.com/remote_file}"
-  checksum "${6:sha256checksum}"
+remote_file '${1:/tmp/remote_file}' do
+  owner '${2:root}'
+  group '${3:root}'
+  mode '${4:0644}'
+  source '${5:http://www.example.com/remote_file}'
+  checksum '${6:sha256checksum}'
 end
 
 ]]></content>

--- a/Remote File/remote_filef.sublime-snippet
+++ b/Remote File/remote_filef.sublime-snippet
@@ -1,13 +1,13 @@
 <snippet>
   <content><![CDATA[
-remote_file "${1:/tmp/remote_file}" do
+remote_file '${1:/tmp/remote_file}' do
   action ${2::create}
   backup ${3:5}
-  owner "${4:root}"
-  group "${5:root}"
-  mode "${6:0644}"
-  source "${7:http://www.example.com/remote_file}"
-  checksum "${8:sha256checksum}"
+  owner '${4:root}'
+  group '${5:root}'
+  mode '${6:0644}'
+  source '${7:http://www.example.com/remote_file}'
+  checksum '${8:sha256checksum}'
 end
 
 ]]></content>

--- a/Remote File/remote_filem.sublime-snippet
+++ b/Remote File/remote_filem.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
   <content><![CDATA[
-remote_file "${1:/tmp/remote_file}" do
+remote_file '${1:/tmp/remote_file}' do
   action ${2::create_if_missing}
-  owner "${3:root}"
-  group "${4:root}"
-  mode "${5:0644}"
-  source "${6:http://www.example.com/remote_file}"
+  owner '${3:root}'
+  group '${4:root}'
+  mode '${5:0644}'
+  source '${6:http://www.example.com/remote_file}'
 end
 
 ]]></content>

--- a/Roles/role.sublime-snippet
+++ b/Roles/role.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
   <content><![CDATA[
-name "${1:role name}"
-description "${2:Description for the role}"
-run_list ${3:"role[example]", "recipe[example]"}
-override_attributes ${4::attribute => "example"}
+name '${1:role name}'
+description '${2:Description for the role}'
+run_list ${3:'role[example]', 'recipe[example]'}
+override_attributes ${4::attribute => 'example'}
 
 ]]></content>
   <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->

--- a/Ruby Block/ruby_block.sublime-snippet
+++ b/Ruby Block/ruby_block.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-ruby_block "${1:reload client config}" do
+ruby_block '${1:reload client config}' do
 	block do
-		${0:Chef::Config.from_file("/etc/chef/client.rb")}
+		${0:Chef::Config.from_file('/etc/chef/client.rb')}
 	end
 end
 

--- a/SCM/git.sublime-snippet
+++ b/SCM/git.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-git "${1:/home/user/deployment}" do
-	repository "${2:git@github.com:gitsite/deployment.git}"
-	reference "${3:master}"
-	user "${4:user}"
-	group "${5:test}"
+git '${1:/home/user/deployment}' do
+	repository '${2:git@github.com:gitsite/deployment.git}'
+	reference '${3:master}'
+	user '${4:user}'
+	group '${5:test}'
 	action :sync
 end
 

--- a/SCM/subversion.sublime-snippet
+++ b/SCM/subversion.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[
-subversion "${1:name}" do
-	destination "${2:/opt/mysources/couch}"
-	repository "${3:http://svn.apache.org/repos/asf/couchdb/trunk}"
-	revision "${4:HEAD}"
-	user "${5:user}"
-	group "${6:test}"
+subversion '${1:name}' do
+	destination '${2:/opt/mysources/couch}'
+	repository '${3:http://svn.apache.org/repos/asf/couchdb/trunk}'
+	revision '${4:HEAD}'
+	user '${5:user}'
+	group '${6:test}'
 	action :sync
 end
 

--- a/Script/bash.sublime-snippet
+++ b/Script/bash.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-bash "${1:install something}" do
-	user "${2:root}"
-	cwd "${3:/tmp}"
+bash '${1:install something}' do
+	user '${2:root}'
+	cwd '${3:/tmp}'
 	code <<-EOH
 	$0
 	EOH

--- a/Script/perl.sublime-snippet
+++ b/Script/perl.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-perl "${1:install something}" do
-	user "${2:root}"
-	cwd "${3:/tmp}"
+perl '${1:install something}' do
+	user '${2:root}'
+	cwd '${3:/tmp}'
 	code <<-EOH
 	$0
 	EOH

--- a/Script/python.sublime-snippet
+++ b/Script/python.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-python "${1:install something}" do
-	user "${2:root}"
-	cwd "${3:/tmp}"
+python '${1:install something}' do
+	user '${2:root}'
+	cwd '${3:/tmp}'
 	code <<-EOH
 	$0
 	EOH

--- a/Script/ruby.sublime-snippet
+++ b/Script/ruby.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-ruby "${1:install something}" do
-	user "${2:root}"
-	cwd "${3:/tmp}"
+ruby '${1:install something}' do
+	user '${2:root}'
+	cwd '${3:/tmp}'
 	code <<-EOH
 	$0
 	EOH

--- a/Script/script.sublime-snippet
+++ b/Script/script.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
-script "${1:install something}" do
-	interpreter "${2:bash}"
-	user "${3:root}"
-	cwd "${4:/tmp}"
+script '${1:install something}' do
+	interpreter '${2:bash}'
+	user '${3:root}'
+	cwd '${4:/tmp}'
 	code <<-EOH
 	$0
 	EOH

--- a/Service/service-pattern.sublime-snippet
+++ b/Service/service-pattern.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
-service "${1:name}" do
-	pattern "${2:pattern}"
+service '${1:name}' do
+	pattern '${2:pattern}'
 	supports :status => ${3:true}, :restart => ${4:true}, :reload => ${5:true}
-	action ${6:[ :enable, :start ]}
+	action ${6:[ :start, :enable ]}
 end
 
 ]]></content>

--- a/Service/service.sublime-snippet
+++ b/Service/service.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
 	<content><![CDATA[
-service "${1:name}" do
+service '${1:name}' do
 	supports :status => ${2:true}, :restart => ${3:true}, :reload => ${4:true}
-	action ${5:[ :enable, :start ]}
+	action ${5:[ :start, :enable ]}
 end
 
 ]]></content>

--- a/Template/template-variables.sublime-snippet
+++ b/Template/template-variables.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-template "${1:name}" do
-	source "${2:source}.erb"
-	owner "root"
-	group "root"
-	mode "0644"
+template '${1:name}' do
+	source '${2:source}.erb'
+	owner 'root'
+	group 'root'
+	mode '0644'
 	variables( ${3::config_var => node[:configs][:config_var]} )
 end
 

--- a/Template/template.sublime-snippet
+++ b/Template/template.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-template "${1:name}" do
-	source "${2:source}.erb"
-	owner "root"
-	group "root"
-	mode "0644"
+template '${1:name}' do
+	source '${2:source}.erb'
+	owner 'root'
+	group 'root'
+	mode '0644'
 end
 
 ]]></content>

--- a/User/user.sublime-snippet
+++ b/User/user.sublime-snippet
@@ -1,13 +1,13 @@
 <snippet>
 	<content><![CDATA[
-user "${1:random}" do
+user '${1:random}' do
 	action :create
-	comment "${2:Random User}"
+	comment '${2:Random User}'
 	uid ${3:1000}
-	gid "${4:users}"
-	home "${5:/home/random}"
-	shell "${6:/bin/zsh}"
-	password "${7:\$1\$JJsvHslV\$szsCjVEroftprNn4JHtDi.}"
+	gid '${4:users}'
+	home '${5:/home/random}'
+	shell '${6:/bin/zsh}'
+	password '${7:\$1\$JJsvHslV\$szsCjVEroftprNn4JHtDi.}'
 	supports :manage_home => true 
 end
 


### PR DESCRIPTION
Now that ChefDK ships with Rubocop, It would be good to update the autocompletes so that code created with this plugin will pass rubocop linting.

Four other changes are also in here:
  - Normalized the order of attributes in the directory resource autocompletes
  - Normalized order of attributes in mount resource autocomplete
  - Added tab stops to the deploy resource autocompletes
  - Update service resource to read ':start, :enable' instead of ':enable, :start' because who would enable a service to start on boot when they aren't sure even sure it will start?

Full changelog for commit:
- Update common conditional not_if/only_if to use single-quotes
- Update cookbook_file resource autocomplete to use single-quotes
- Update cron resource autocomplete to use single-quotes
- Update deploy resource autocomplete to use single-quotes
- Add tab stops to deploy resource autocomplete
- Update directory resource autocomplete to use single-quotes
- Normalized order of attributes in directory resource autocomplete
- Update erl_call resource autocomplete to use single-quotes
- Update execute resource autocomplete to use single-quotes
- Update env resource autocomplete to use single-quotes
- Update file resource autocomplete to use single-quotes
- Update group resource autocomplete to use single-quotes
- Update http_request resource autocomplete to use single-quotes
- Update include_recipe resource autocomplete to use single-quotes
- Update link resource autocomplete to use single-quotes
- Update log resource autocomplete to use single-quotes
- Update mdadm resource autocomplete to use single-quotes
- Update metadata generator autocomplete to use single-quotes
- Update metadata generator pre-fills to match those created by chef generate
- Update mount resource autocomplete to use single-quotes
- Normalized order of attributes in mount resource autocomplete
- Update notifies autocompletes to use single-quotes
- Update ohai resource autocomplete to use single-quotes
- Update package resource autocomplete to use single-quotes
- Update remote_directory resource autocomplete to use single-quotes
- Update remote_file resource autocomplete to use single-quotes
- Update role autocomplete to use single-quotes
- Update ruby_block resource autocomplete to use single-quotes
- Update scm_git resource autocomplete to use single-quotes
- Update scm_svn resource autocomplete to use single-quotes
- Update script resource autocomplete to use single-quotes
- Update service resource autocomplete to use single-quotes
- Update service resource to read ':start, :enable' instead of ':enable, :start' because who would enable a service to start on boot when they aren't sure even sure it will start?
- Update template resource autocomplete to use single-quotes
- Update user resource autocomplete to use single-quotes
